### PR TITLE
Fix #18 Change date format to avoid Safari (also other iPhone browsers) issues

### DIFF
--- a/src/components/ActivityChart.tsx
+++ b/src/components/ActivityChart.tsx
@@ -79,7 +79,7 @@ interface Activity {
  * @returns Jan
  */
 function monthNumToShort(month: number) {
-  const mockDate = new Date(`2020-${month + 1}-1`);
+  const mockDate = new Date(new Date(`2020/${month + 1}/1`).getTime()); // UTC date - Safari bug /-
   return new Intl.DateTimeFormat("en-US", { month: "short" }).format(mockDate);
 }
 


### PR DESCRIPTION
Screenshot below:

<img width="1552" alt="Screenshot 2021-12-03 at 17 43 43" src="https://user-images.githubusercontent.com/7695193/144640036-9bc161b4-a150-4d60-85d6-f96e695271a0.png">

