### PR TITLE
Change Infura URL on the package viewer iframe

### DIFF
--- a/src/settingsContext.ts
+++ b/src/settingsContext.ts
@@ -8,7 +8,7 @@ interface Settings {
 
 const SettingsContext = React.createContext<Settings>({
   ipfsGateway: "https://gateway.ipfs.dappnode.io",
-  ipfsApi: "https://ipfs.infura.io:5001",
+  ipfsApi: "https://infura-ipfs.io:5001",
   txViewer: "https://etherscan.io/tx",
 });
 


### PR DESCRIPTION
The pages is showing an error message in the iframe:

Domain ipfs.infura.io isn't active anymore. Use infura-ipfs.io

I have made this edit in the code (I think...).
![Infura URL Change](https://user-images.githubusercontent.com/2583972/188498984-45790231-fecc-4111-b15d-2c8dea969e9b.jpg)
